### PR TITLE
Add Duffel flight search integration

### DIFF
--- a/duffel_search.html
+++ b/duffel_search.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AMEX Partner Search via Duffel</title>
+  <style>
+    body { font-family: sans-serif; margin: 40px; }
+    input, button { padding: 8px; margin: 4px; }
+    .offer { border: 1px solid #ccc; padding: 8px; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Search Flights with Amex Partners</h1>
+  <form id="searchForm">
+    <label>Origin: <input id="origin" required></label>
+    <label>Destination: <input id="destination" required></label>
+    <label>Departure Date: <input id="date" type="date" required></label>
+    <button type="submit">Search</button>
+  </form>
+
+  <div id="results"></div>
+
+  <script>
+    document.getElementById('searchForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const origin = document.getElementById('origin').value.trim();
+      const destination = document.getElementById('destination').value.trim();
+      const date = document.getElementById('date').value;
+
+      const res = await fetch('/api/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ origin, destination, departureDate: date })
+      });
+
+      const data = await res.json();
+      const container = document.getElementById('results');
+      container.innerHTML = '';
+
+      if (Array.isArray(data.offers)) {
+        data.offers.forEach(offer => {
+          const div = document.createElement('div');
+          div.className = 'offer';
+          div.textContent = `${offer.owner.name} - ${offer.total_amount} ${offer.total_currency}`;
+          container.appendChild(div);
+        });
+      } else if (data.error) {
+        container.textContent = data.error;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cheerio": "^1.0.0-rc.12"
+    "@duffel/api": "^4.12.2",
+    "express": "^4.18.2"
   },
   "type": "module"
 }

--- a/server.js
+++ b/server.js
@@ -1,110 +1,52 @@
-// server.js  ────────────────────────────────────────────────────────────────
 import express from 'express';
-// Modules for the old scraping approach (left for reference)
-import * as cheerio from 'cheerio';
-import { exec as _exec } from 'child_process';
-import { promisify } from 'util';
-
-// ⬇️ NEW: path helpers so we can send files in an ES-module
+import { Duffel } from '@duffel/api';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
-// ───────────────────────────────────────────────────────────────────────────
-
-const exec = promisify(_exec);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(express.json());
-
-// ⬇️ NEW: serve any static file (HTML/CSS/JS) in the same folder
 app.use(express.static(__dirname));
 
-/**
- * List of partner websites with placeholder URLs. Replace with the
- * real search endpoints or add any extra query parameters you need.
- */
-const partners = [
-  {
-    code: 'DL',
-    name: 'Delta Air Lines',
-    url: 'https://www.delta.com/flight-search/book-a-flight',
-    buildQuery: p =>
-      `?fromCity=${p.origin}&toCity=${p.destination}&departureDate=${p.date}`,
-  },
-  {
-    code: 'AF',
-    name: 'Air France',
-    url: 'https://wwws.airfrance.us/booking/search-flight',
-    buildQuery: p =>
-      `?origin=${p.origin}&destination=${p.destination}&departureDate=${p.date}`,
-  },
-  {
-    code: 'BA',
-    name: 'British Airways',
-    url: 'https://www.britishairways.com/travel/booking',
-    buildQuery: p =>
-      `?source=${p.origin}&destination=${p.destination}&depDate=${p.date}`,
-  },
-];
+const duffel = new Duffel({ token: process.env.DUFFEL_ACCESS_TOKEN || '' });
 
-
-/**
- * Basic scraper that curls the partner site and extracts data.
- * The CSS selectors here are placeholders—update them for each airline.
- */
-async function scrapePartner(partner, params) {
-  const query = partner.buildQuery
-    ? partner.buildQuery(params)
-    : `?origin=${params.origin}&destination=${params.destination}&date=${params.date}`;
-
-  const searchUrl = `${partner.url}${query}`;
-
-  // Use curl—handy when fetch is blocked or TLS quirks exist.
-  const command = `curl -LsA "Mozilla/5.0" "${searchUrl}"`;
-  const { stdout } = await exec(command, { maxBuffer: 10_000_000 });
-
-  const $ = cheerio.load(stdout);
-  const flights = [];
-
-  $('.flight').each((_, el) => {
-    flights.push({
-      partner: partner.name,
-      cabin:  $(el).find('.cabin').text().trim(),
-      points: parseInt($(el).find('.points').text().replace(/\D/g, ''), 10),
-      // add more fields as needed
-    });
-  });
-
-  return flights;
-}
-
-// ── API endpoint ───────────────────────────────────────────────────────────
-app.post('/search', async (req, res) => {
-  const { origin, destination, date, cabin = 'economy', partnerCode } = req.body;
-  const searchPartners = partnerCode
-    ? partners.filter(p => p.code === partnerCode)
-    : partners;
-
-  const results = [];
-
-  for (const partner of searchPartners) {
-    try {
-      const flights = await scrapePartner(partner, { origin, destination, date, cabin });
-      results.push(...flights);
-    } catch (err) {
-      console.error(`Failed to scrape ${partner.name}:`, err.message);
-    }
+app.post('/api/search', async (req, res) => {
+  const { origin, destination, departureDate } = req.body;
+  if (!origin || !destination || !departureDate) {
+    return res.status(400).json({ error: 'Missing parameters' });
   }
 
-  res.json({ results });
+  try {
+    const offerRequest = await duffel.offerRequests.create({
+      slices: [
+        {
+          origin,
+          destination,
+          departure_date: departureDate,
+        },
+      ],
+      passengers: [{ type: 'adult' }],
+      return_offers: false,
+    });
+
+    const offers = await duffel.offers.list({
+      offer_request_id: offerRequest.data.id,
+      limit: 20,
+    });
+
+    res.json({ offers: offers.data });
+  } catch (err) {
+    console.error('Duffel API error', err);
+    res.status(500).json({ error: 'Duffel API request failed' });
+  }
 });
 
-// Redirect the root to the landing page
-app.get('/', (_, res) => res.redirect('/index.html'));
+app.get('/', (_, res) => {
+  res.sendFile('duffel_search.html', { root: __dirname });
+});
 
-// ── Launch server ──────────────────────────────────────────────────────────
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- integrate Duffel API in server
- add simple Duffel search UI
- drop old scraping deps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5e29a4e48322a59140242315f178